### PR TITLE
core(package.json): Make peer dependencies less restrictive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lib-cov
 node_modules
 
 # Other
+.idea
 .DS_Store
 dist/
 lib/

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@xstate/react": "^3.0.0",
-    "react": "^18.2.0",
+    "react": "^17.0.0 || ^18.0.0",
     "xstate": "^4.32.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I have try to use you (very good thanks) library in a repo that uses react@^17.0.0 and get into peer dependency issues.
As it seems that your library could work with react@^17.0.0, I make a proposal, include this version as valide peer dependency. Wdyt?